### PR TITLE
Increase version of dependency for security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea
+.classpath
+.project
+.settings

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.7</version>
+            <version>[2.9.8,)</version>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>


### PR DESCRIPTION

This update will increase version of Jackson-databind based on
the security alert from GitHub.